### PR TITLE
Disable transform on scrollview's subviews when reached the top

### DIFF
--- a/Source/ScrollViewUpdater.swift
+++ b/Source/ScrollViewUpdater.swift
@@ -82,9 +82,9 @@ final class ScrollViewUpdater {
         } else {
             if scrollView.isDecelerating {
                 rootView.transform = CGAffineTransform(translationX: 0, y: -offset)
-                scrollView.subviews.forEach {
-                    $0.transform = CGAffineTransform(translationX: 0, y: offset)
-                }
+//                scrollView.subviews.forEach {
+//                    $0.transform = CGAffineTransform(translationX: 0, y: offset)
+//                }
             } else {
                 scrollView.bounces = false
                 isDismissEnabled = true


### PR DESCRIPTION
Minor regression being the scroll view still bounces at the top even though the parent view controller bounces.

Bug to track: https://github.com/HarshilShah/DeckTransition/issues/62